### PR TITLE
feat: remove firebase auth and start at lobby

### DIFF
--- a/app/public/src/game/scenes/game-scene.ts
+++ b/app/public/src/game/scenes/game-scene.ts
@@ -1,5 +1,4 @@
 import { Room } from "colyseus.js"
-import firebase from "firebase/compat/app"
 import { GameObjects, Scene } from "phaser"
 import OutlinePlugin from "phaser3-rex-plugins/plugins/outlinepipeline-plugin"
 import { DesignTiled } from "../../../../core/design"
@@ -29,6 +28,7 @@ import { clearTitleNotificationIcon } from "../../../../utils/window"
 import { playMusic, playSound, SOUNDS } from "../../pages/utils/audio"
 import { transformBoardCoordinates } from "../../pages/utils/utils"
 import { preference } from "../../preferences"
+import store from "../../stores"
 import AnimationManager from "../animation-manager"
 import BattleManager from "../components/battle-manager"
 import BoardManager from "../components/board-manager"
@@ -80,7 +80,7 @@ export default class GameScene extends Scene {
     this.tilemaps = new Map()
     this.room = data.room
     this.spectate = data.spectate
-    this.uid = firebase.auth().currentUser?.uid
+    this.uid = store.getState().network.uid
     this.started = false
   }
 

--- a/app/public/src/index.tsx
+++ b/app/public/src/index.tsx
@@ -3,7 +3,6 @@ import { createRoot } from "react-dom/client"
 import { Provider } from "react-redux"
 import { BrowserRouter, Route, Routes } from "react-router-dom"
 import AfterGame from "./pages/after-game"
-import Auth from "./pages/auth"
 import BotBuilder from "./pages/component/bot-builder/bot-builder"
 import { BotManagerPanel } from "./pages/component/bot-builder/bot-manager-panel"
 import MapViewer from "./pages/component/debug/map-viewer"
@@ -39,7 +38,7 @@ root.render(
           v7_relativeSplatPath: true,
         }}>
           <Routes>
-            <Route path="/" element={<Auth />} />
+            <Route path="/" element={<Lobby />} />
             <Route path="/lobby" element={<Lobby />} />
             <Route path="/preparation" element={<Preparation />} />
             <Route path="/game" element={<Game />} />

--- a/app/public/src/pages/component/bot-builder/bot-builder.tsx
+++ b/app/public/src/pages/component/bot-builder/bot-builder.tsx
@@ -1,4 +1,3 @@
-import firebase from "firebase/compat/app"
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { useNavigate } from "react-router"
@@ -317,12 +316,10 @@ export function SubmitBotModal(props: {
     setError("")
     setSuccess(false)
     try {
-      const token = await firebase.auth().currentUser?.getIdToken()
       const res = await fetch("/bots", {
         method: "POST",
         headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`
+          "Content-Type": "application/json"
         },
         body: JSON.stringify(props.bot)
       })

--- a/app/public/src/pages/component/bot-builder/bot-manager-panel.tsx
+++ b/app/public/src/pages/component/bot-builder/bot-manager-panel.tsx
@@ -1,4 +1,3 @@
-import firebase from "firebase/compat/app"
 import { useEffect, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { useNavigate } from "react-router-dom"
@@ -75,12 +74,8 @@ function BotsList(props: { approved?: boolean }) {
       )
     )
       return
-    const token = await firebase.auth().currentUser?.getIdToken()
     const res = await fetch(`/bots/${bot.id}`, {
-      method: "DELETE",
-      headers: {
-        Authorization: `Bearer ${token}`
-      }
+      method: "DELETE"
     })
     if (res.ok) {
       setBots((bots) => bots?.filter((b) => b.id !== bot.id) ?? [])
@@ -88,11 +83,9 @@ function BotsList(props: { approved?: boolean }) {
   }
 
   async function approveBot(botId: string, approved: boolean) {
-    const token = await firebase.auth().currentUser?.getIdToken()
     const res = await fetch(`/bots/${botId}/approve`, {
       method: "POST",
       headers: {
-        Authorization: `Bearer ${token}`,
         "Content-Type": "application/json"
       },
       body: JSON.stringify({ approved })

--- a/app/public/src/pages/component/preparation/preparation-menu.tsx
+++ b/app/public/src/pages/component/preparation/preparation-menu.tsx
@@ -1,5 +1,4 @@
 import { Room } from "colyseus.js"
-import firebase from "firebase/compat/app"
 import React, { useEffect, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { IGameUser } from "../../../../../models/colyseus-models/game-user"
@@ -116,10 +115,7 @@ export default function PreparationMenu() {
 
   const startGame = throttle(async function startGame() {
     if (room) {
-      const token = await firebase.auth().currentUser?.getIdToken()
-      if (token) {
-        dispatch(gameStartRequest(token))
-      }
+      dispatch(gameStartRequest())
     }
   }, 1000)
 

--- a/app/public/src/pages/component/room-menu/game-rooms-menu.tsx
+++ b/app/public/src/pages/component/room-menu/game-rooms-menu.tsx
@@ -1,5 +1,4 @@
 import { Client, Room, RoomAvailable } from "colyseus.js"
-import firebase from "firebase/compat/app"
 import React, { useState } from "react"
 import { useTranslation } from "react-i18next"
 import { useNavigate } from "react-router-dom"
@@ -29,15 +28,15 @@ export function IngameRoomsList() {
     (state) => state.network.lobby
   )
   const user = useAppSelector((state) => state.network.profile)
+  const uid = useAppSelector((state) => state.network.uid)
 
   const joinGame = throttle(async function joinGame(
     selectedRoom: RoomAvailable<IGameMetadata>
   ) {
-    const token = await firebase.auth().currentUser?.getIdToken()
-    if (lobby && !isJoining && token) {
+    if (lobby && !isJoining && uid) {
       setJoining(true)
       const game: Room<GameState> = await client.joinById(selectedRoom.roomId, {
-        idToken: token
+        uid
       })
       localStore.set(
         LocalStoreKeys.RECONNECTION_GAME,

--- a/app/public/src/pages/game.tsx
+++ b/app/public/src/pages/game.tsx
@@ -1,5 +1,4 @@
 import { Client, getStateCallbacks, Room } from "colyseus.js"
-import firebase from "firebase/compat/app"
 import { useCallback, useEffect, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { useNavigate } from "react-router-dom"
@@ -218,8 +217,6 @@ export default function Game() {
   const leave = useCallback(async () => {
     const afterPlayers = new Array<IAfterGamePlayer>()
 
-    const token = await firebase.auth().currentUser?.getIdToken()
-
     if (gameContainer && gameContainer.game) {
       gameContainer.game.destroy(true)
     }
@@ -286,9 +283,10 @@ export default function Game() {
       afterPlayers.filter((p) => p.role !== Role.BOT).length >= 2
     const gameMode = room?.state.gameMode
 
+    const uid = store.getState().network.uid
     const r: Room<AfterGameState> = await client.create("after-game", {
       players: afterPlayers,
-      idToken: token,
+      uid,
       elligibleToXP,
       elligibleToELO,
       gameMode

--- a/app/public/src/pages/lobby.tsx
+++ b/app/public/src/pages/lobby.tsx
@@ -1,5 +1,4 @@
 import { Room, RoomAvailable } from "colyseus.js"
-import firebase from "firebase/compat/app"
 import React, { useCallback, useEffect, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { useNavigate } from "react-router-dom"
@@ -7,6 +6,7 @@ import GameState from "../../../rooms/states/game-state"
 import { throttle } from "../../../utils/function"
 import { joinLobbyRoom } from "../game/lobby-logic"
 import { useAppDispatch, useAppSelector } from "../hooks"
+import store from "../stores"
 import { resetLobby } from "../stores/LobbyStore"
 import {
   logOut,
@@ -49,17 +49,16 @@ export default function Lobby() {
     if (lobby?.connection.isOpen) {
       await lobby.leave()
     }
-    await firebase.auth().signOut()
     dispatch(resetLobby())
     dispatch(logOut())
     navigate("/")
   }, [dispatch, lobby])
 
   const reconnectToGame = throttle(async function reconnectToGame() {
-    const idToken = await firebase.auth().currentUser?.getIdToken()
-    if (idToken && pendingGameId) {
+    const uid = store.getState().network.uid
+    if (uid && pendingGameId) {
       const game: Room<GameState> = await client.joinById(pendingGameId, {
-        idToken
+        uid
       })
       localStore.set(
         LocalStoreKeys.RECONNECTION_GAME,

--- a/app/public/src/pages/preparation.tsx
+++ b/app/public/src/pages/preparation.tsx
@@ -1,5 +1,4 @@
 import { Client, getStateCallbacks, Room } from "colyseus.js"
-import firebase from "firebase/compat/app"
 import React, { useCallback, useEffect, useRef } from "react"
 import { useTranslation } from "react-i18next"
 import { useNavigate } from "react-router-dom"
@@ -14,6 +13,7 @@ import type { NonFunctionPropNames } from "../../../types/HelperTypes"
 import { logger } from "../../../utils/logger"
 import { useAppDispatch, useAppSelector } from "../hooks"
 import { authenticateUser } from "../network"
+import store from "../stores"
 import {
   joinPreparation,
   setConnectionStatus,
@@ -260,12 +260,12 @@ export default function Preparation() {
       })
 
       room.onMessage(Transfer.GAME_START, async (roomId) => {
-        const token = await firebase.auth().currentUser?.getIdToken()
-        if (token && !connectingToGame.current) {
+        const uid = store.getState().network.uid
+        if (!connectingToGame.current) {
           playSound(SOUNDS.START_GAME)
           connectingToGame.current = true
           const game: Room<GameState> = await client.joinById(roomId, {
-            idToken: token
+            uid
           })
           localStore.set(
             LocalStoreKeys.RECONNECTION_GAME,

--- a/app/public/src/stores/NetworkStore.ts
+++ b/app/public/src/stores/NetworkStore.ts
@@ -1,4 +1,3 @@
-import { User } from "@firebase/auth-types"
 import { createSlice, PayloadAction } from "@reduxjs/toolkit"
 import { Client, Room } from "colyseus.js"
 import { CollectionUtils } from "../../../core/collection"
@@ -64,7 +63,10 @@ export const networkSlice = createSlice({
   name: "network",
   initialState: initalState,
   reducers: {
-    logIn: (state, action: PayloadAction<User>) => {
+    logIn: (
+      state,
+      action: PayloadAction<{ uid: string; displayName?: string }>,
+    ) => {
       if (action.payload) {
         state.uid = action.payload.uid
         state.displayName = action.payload.displayName ?? "Anonymous"
@@ -192,10 +194,8 @@ export const networkSlice = createSlice({
     itemClick: (state, action: PayloadAction<Item>) => {
       state.game?.send(Transfer.ITEM, action.payload)
     },
-    gameStartRequest: (state, action: PayloadAction<string>) => {
-      state.preparation?.send(Transfer.GAME_START_REQUEST, {
-        token: action.payload
-      })
+    gameStartRequest: (state) => {
+      state.preparation?.send(Transfer.GAME_START_REQUEST)
     },
     changeRoomName: (state, action: PayloadAction<string>) => {
       state.preparation?.send(Transfer.CHANGE_ROOM_NAME, action.payload)

--- a/app/rooms/custom-lobby-room.ts
+++ b/app/rooms/custom-lobby-room.ts
@@ -1,7 +1,6 @@
 import { Dispatcher } from "@colyseus/command"
 import { Client, IRoomCache, matchMaker, Room, subscribeLobby } from "colyseus"
 import { CronJob } from "cron"
-import admin from "firebase-admin"
 import Message from "../models/colyseus-models/message"
 import { TournamentSchema } from "../models/colyseus-models/tournament"
 import { IBot } from "../models/mongo-models/bot-v2"
@@ -422,20 +421,13 @@ export default class CustomLobbyRoom extends Room<LobbyState> {
     this.fetchTournaments()
   }
 
-  async onAuth(client: Client, options, context) {
+  async onAuth(client: Client, options: any, context: any) {
     try {
       super.onAuth(client, options, context)
-      const token = await admin.auth().verifyIdToken(options.idToken)
-      const user = await admin.auth().getUser(token.uid)
-
-      if (!user.displayName) {
-        logger.error("No display name for this account", user.uid)
-        throw new Error(
-          "No display name for this account. Please report this error."
-        )
+      return {
+        uid: options.uid ?? client.sessionId,
+        displayName: options.displayName ?? "Guest",
       }
-
-      return user
     } catch (error) {
       logger.error(`Error on authentication on lobby room`, error)
       throw error // https://docs.colyseus.io/community/deny-player-join-a-room/

--- a/app/rooms/game-room.ts
+++ b/app/rooms/game-room.ts
@@ -1,7 +1,6 @@
 import { Dispatcher } from "@colyseus/command"
 import { MapSchema } from "@colyseus/schema"
 import { Client, Room } from "colyseus"
-import admin from "firebase-admin"
 import { nanoid } from "nanoid"
 import { computeElo } from "../core/elo"
 import { CountEvolutionRule, ItemEvolutionRule } from "../core/evolution-rules"
@@ -535,20 +534,13 @@ export default class GameRoom extends Room<GameState> {
     this.miniGame.initialize(this.state, this)
   }
 
-  async onAuth(client: Client, options, context) {
+  async onAuth(client: Client, options: any, context: any) {
     try {
       super.onAuth(client, options, context)
-      const token = await admin.auth().verifyIdToken(options.idToken)
-      const user = await admin.auth().getUser(token.uid)
-
-      if (!user.displayName) {
-        logger.error("No display name for this account", user.uid)
-        throw new Error(
-          "No display name for this account. Please report this error."
-        )
+      return {
+        uid: options.uid ?? client.sessionId,
+        displayName: options.displayName ?? "Guest",
       }
-
-      return user
     } catch (error) {
       logger.error(error)
     }


### PR DESCRIPTION
## Summary
- drop firebase authentication and use offline uid
- default to lobby instead of login page
- allow game flow and bot tools without firebase tokens

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898f5664508833287bc81ffb2195cd4